### PR TITLE
[MCTB-468] Implementation of Users (#3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/mitchellh/mapstructure v1.4.1
-	github.com/nordcloud/go-pingdom v1.3.2-0.20210406113751-d4f206ed9396
+	github.com/nordcloud/go-pingdom v1.3.2-0.20210412074732-11355fe8e82d
 	github.com/zclconf/go-cty v1.7.1 // indirect
 	golang.org/x/tools v0.0.0-20201028111035-eafbe7b904eb // indirect
 	google.golang.org/api v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,8 @@ github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY7
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nordcloud/go-pingdom v1.3.2-0.20210406113751-d4f206ed9396 h1:bszVAUcsqL/Aou/LrdhV3+cDQU23xGWUxEl9uTHCzVQ=
-github.com/nordcloud/go-pingdom v1.3.2-0.20210406113751-d4f206ed9396/go.mod h1:Oae/W4lhmlxJ0y30bIXGv5981ni9TJSGjW4gbkqHjsA=
+github.com/nordcloud/go-pingdom v1.3.2-0.20210412074732-11355fe8e82d h1:tx3g5Rc2i9ymeGytNfgxFlkSvDiZnkl32gn7Z9VMfc0=
+github.com/nordcloud/go-pingdom v1.3.2-0.20210412074732-11355fe8e82d/go.mod h1:Oae/W4lhmlxJ0y30bIXGv5981ni9TJSGjW4gbkqHjsA=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/pingdom/data_source_pingdom_contact.go
+++ b/pingdom/data_source_pingdom_contact.go
@@ -87,7 +87,6 @@ func dataSourcePingdomContact() *schema.Resource {
 
 func dataSourcePingdomContactRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*Clients).Pingdom
-
 	name := d.Get("name").(string)
 	contacts, err := client.Contacts.List()
 	log.Printf("[DEBUG] contacts : %v", contacts)

--- a/pingdom/provider.go
+++ b/pingdom/provider.go
@@ -28,6 +28,9 @@ func Provider() *schema.Provider {
 			"pingdom_team":        resourcePingdomTeam(),
 			"pingdom_contact":     resourcePingdomContact(),
 			"pingdom_integration": resourcePingdomIntegration(),
+			"pingdom_maintenance": resourcePingdomMaintenance(),
+			"pingdom_user":       resourceSolarwindsUser(),
+			"pingdom_occurrence": resourcePingdomOccurrences(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"pingdom_contact": dataSourcePingdomContact(),

--- a/pingdom/provider_test.go
+++ b/pingdom/provider_test.go
@@ -29,37 +29,26 @@ func TestProvider(t *testing.T) {
 
 func TestProviderConfigure(t *testing.T) {
 	var expectedToken string
-	var expectedUser string
-	var expectedPassword string
 
+	var isAccTestEnabled bool
+	if v := os.Getenv("TF_ACC"); v != "" {
+		isAccTestEnabled = true
+	}
 	if v := os.Getenv("PINGDOM_API_TOKEN"); v != "" {
 		expectedToken = v
 	} else {
 		expectedToken = "foo"
 	}
 
-	if v := os.Getenv("SOLARWINDS_USER"); v != "" {
-		expectedUser = v
-	} else {
-		expectedUser = "foo"
-	}
-
-	if v := os.Getenv("SOLARWINDS_PASSWD"); v != "" {
-		expectedPassword = v
-	} else {
-		expectedPassword = "foo"
-	}
-
 	raw := map[string]interface{}{
-		"api_token":         expectedToken,
-		"solarwinds_user":   expectedUser,
-		"solarwinds_passwd": expectedPassword,
-	}
-	var isAccTestEnabled bool
-	if v := os.Getenv("TF_ACC"); v != "" {
-		isAccTestEnabled = true
+		"api_token": expectedToken,
 	}
 
+	// Previously there is only one client, which is the Pingdom client. It does not require obtaining any kind of
+	// token during its initialization process, thus it will not verify whether the token provided is valid or not.
+	// However, the case is different for the Solarwinds client because it will not initialize successfully unless
+	// there are real user credentials provided.	In this case, we need to skip the init process to avoid any test
+	// errors if the credentials are not provided.
 	if isAccTestEnabled {
 		rp := Provider()
 		err := rp.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
@@ -67,13 +56,12 @@ func TestProviderConfigure(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		config := rp.Meta().(*Clients).Pingdom
+		pingdomClient := rp.Meta().(*Clients).Pingdom
 
-		if config.APIToken != expectedToken {
-			t.Fatalf("bad: %#v", config)
+		if pingdomClient.APIToken != expectedToken {
+			t.Fatalf("bad: %#v", pingdomClient)
 		}
 	}
-
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/pingdom/resource_pingdom_check.go
+++ b/pingdom/resource_pingdom_check.go
@@ -453,7 +453,7 @@ func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
 }
 
 func resourcePingdomCheckCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*pingdom.Client)
+	client := meta.(*Clients).Pingdom
 
 	check, err := checkForResource(d)
 	if err != nil {
@@ -664,7 +664,7 @@ func resourcePingdomCheckRead(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourcePingdomCheckUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*pingdom.Client)
+	client := meta.(*Clients).Pingdom
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {

--- a/pingdom/resource_pingdom_check_test.go
+++ b/pingdom/resource_pingdom_check_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/nordcloud/go-pingdom/pingdom"
 )
 
 func TestAccResourcePingdomCheck_http(t *testing.T) {
@@ -203,7 +202,7 @@ func TestAccResourcePingdomCheck_dns(t *testing.T) {
 }
 
 func testAccCheckPingdomCheckDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*pingdom.Client)
+	client := testAccProvider.Meta().(*Clients).Pingdom
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "pingdom_check" {

--- a/pingdom/resource_pingdom_contact_test.go
+++ b/pingdom/resource_pingdom_contact_test.go
@@ -85,7 +85,7 @@ func TestAccResourcePingdomContact_basic(t *testing.T) {
 }
 
 func testAccCheckPingdomContactDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*pingdom.Client)
+	client := testAccProvider.Meta().(*Clients).Pingdom
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "pingdom_contact" {

--- a/pingdom/resource_pingdom_maintenance.go
+++ b/pingdom/resource_pingdom_maintenance.go
@@ -1,0 +1,231 @@
+package pingdom
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nordcloud/go-pingdom/pingdom"
+	"strconv"
+	"strings"
+)
+
+func resourcePingdomMaintenance() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePingdomMaintenanceCreate,
+		ReadContext:   resourcePingdomMaintenanceRead,
+		UpdateContext: resourcePingdomMaintenanceUpdate,
+		DeleteContext: resourcePingdomMaintenanceDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"from": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"to": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"effectiveto": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"recurrencetype": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "none",
+			},
+			"repeatevery": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"tmsids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"uptimeids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+		},
+	}
+}
+
+func maintenanceForResource(d *schema.ResourceData) (*pingdom.MaintenanceWindow, error) {
+	maintenance := pingdom.MaintenanceWindow{}
+
+	// required
+	if v, ok := d.GetOk("description"); ok {
+		maintenance.Description = v.(string)
+	}
+
+	if v, ok, err := getTime("from", d); err != nil {
+		return nil, err
+	} else if ok {
+		maintenance.From = v
+	}
+
+	if v, ok, err := getTime("to", d); err != nil {
+		return nil, err
+	} else if ok {
+		maintenance.To = v
+	}
+
+	if v, ok, err := getTime("effectiveto", d); err != nil {
+		return nil, err
+	} else if ok {
+		maintenance.EffectiveTo = v
+	}
+
+	if v, ok := d.GetOk("recurrencetype"); ok {
+		maintenance.RecurrenceType = v.(string)
+	}
+
+	if v, ok := d.GetOk("repeatevery"); ok {
+		maintenance.RepeatEvery = v.(int)
+	}
+
+	if v, ok := d.GetOk("tmsids"); ok {
+		maintenance.TmsIDs = convertIntInterfaceSliceToString(v.(*schema.Set).List())
+	}
+
+	if v, ok := d.GetOk("uptimeids"); ok {
+		maintenance.UptimeIDs = convertIntInterfaceSliceToString(v.(*schema.Set).List())
+	}
+
+	return &maintenance, nil
+}
+
+func updateResourceFromMaintenanceResponse(d *schema.ResourceData, m *pingdom.MaintenanceResponse) error {
+	if err := d.Set("description", m.Description); err != nil {
+		return err
+	}
+
+	if err := d.Set("from", timeFormat(m.From)); err != nil {
+		return err
+	}
+
+	if err := d.Set("to", timeFormat(m.To)); err != nil {
+		return err
+	}
+
+	if err := d.Set("effectiveto", timeFormat(m.EffectiveTo)); err != nil {
+		return err
+	}
+
+	if err := d.Set("recurrencetype", m.RecurrenceType); err != nil {
+		return err
+	}
+
+	if err := d.Set("repeatevery", m.RepeatEvery); err != nil {
+		return err
+	}
+
+	tmsids := schema.NewSet(
+		func(tmsId interface{}) int { return tmsId.(int) },
+		[]interface{}{},
+	)
+	for _, tms := range m.Checks.Tms {
+		tmsids.Add(tms)
+	}
+	if err := d.Set("tmsids", tmsids); err != nil {
+		return err
+	}
+
+	uptimeids := schema.NewSet(
+		func(uptimeId interface{}) int { return uptimeId.(int) },
+		[]interface{}{},
+	)
+	for _, uptime := range m.Checks.Uptime {
+		uptimeids.Add(uptime)
+	}
+	if err := d.Set("uptimeids", uptimeids); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourcePingdomMaintenanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Pingdom
+
+	maintenance, err := maintenanceForResource(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	result, err := client.Maintenances.Create(maintenance)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(strconv.Itoa(result.ID))
+
+	return nil
+}
+
+func resourcePingdomMaintenanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Pingdom
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.Errorf("Error retrieving id for resource: %s", err)
+	}
+	maintenance, err := client.Maintenances.Read(id)
+	if err != nil {
+		return diag.Errorf("Error retrieving maintenance: %s", err)
+	}
+
+	if err := updateResourceFromMaintenanceResponse(d, maintenance); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePingdomMaintenanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Pingdom
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.Errorf("Error retrieving id for resource: %s", err)
+	}
+	maintenance, err := maintenanceForResource(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if _, err = client.Maintenances.Update(id, maintenance); err != nil {
+		return diag.Errorf("Error updating maintenance: %s", err)
+	}
+
+	return nil
+}
+
+func resourcePingdomMaintenanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Pingdom
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.Errorf("Error retrieving id for resource: %s", err)
+	}
+	if _, err := client.Maintenances.Delete(id); err != nil {
+		return diag.Errorf("Error deleting maintenance: %s", err)
+	}
+	return nil
+}
+
+func convertIntInterfaceSliceToString(slice []interface{}) string {
+	stringSlice := make([]string, len(slice))
+	for i := range slice {
+		stringSlice[i] = strconv.Itoa(slice[i].(int))
+	}
+	return strings.Join(stringSlice, ",")
+}

--- a/pingdom/resource_pingdom_maintenance_test.go
+++ b/pingdom/resource_pingdom_maintenance_test.go
@@ -1,0 +1,114 @@
+package pingdom
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccResourcePingdomMaintenance_basic(t *testing.T) {
+	resourceName := "pingdom_maintenance.test"
+	checkResourceName := "pingdom_check.test"
+
+	description := acctest.RandomWithPrefix("tf-acc-test")
+	updatedDescription := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPingdomMaintenanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourcePingdomMaintenanceConfig(description),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPingdomResourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "from", "2066-01-02T22:00:00+08:00"),
+					resource.TestCheckResourceAttr(resourceName, "to", "2066-01-02T23:00:00+08:00"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccResourcePingdomMaintenanceConfigUpdate(updatedDescription),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPingdomResourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
+					resource.TestCheckResourceAttr(resourceName, "from", "2066-01-05T22:10:00+08:00"),
+					resource.TestCheckResourceAttr(resourceName, "to", "2066-01-05T23:59:00+08:00"),
+					resource.TestCheckResourceAttr(resourceName, "effectiveto", "2088-10-22T06:07:08+08:00"),
+					resource.TestCheckResourceAttr(resourceName, "recurrencetype", "week"),
+					resource.TestCheckResourceAttr(resourceName, "repeatevery", "4"),
+					resource.TestCheckResourceAttr(resourceName, "uptimeids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "uptimeids.*", checkResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPingdomMaintenanceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Clients).Pingdom
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "pingdom_maintenance" {
+			continue
+		}
+
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Maintenance ID is not valid: %s", rs.Primary.ID)
+		}
+
+		resp, err := client.Maintenances.Read(id)
+		if err == nil {
+			if strconv.Itoa(resp.ID) == rs.Primary.ID {
+				return fmt.Errorf("Maintenance (%s) still exists.", rs.Primary.ID)
+			}
+		}
+
+		if !strings.Contains(err.Error(), "404") {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccResourcePingdomMaintenanceConfig(name string) string {
+	return fmt.Sprintf(`
+resource "pingdom_maintenance" "test" {
+	description = "%s"
+	from        = "2066-01-02T22:00:00+08:00"
+	to          = "2066-01-02T23:00:00+08:00"
+}
+`, name)
+}
+
+func testAccResourcePingdomMaintenanceConfigUpdate(name string) string {
+	return fmt.Sprintf(`
+resource "pingdom_check" "test" {
+	name = "%s"
+	host = "www.example.com"
+	type = "http"
+}
+
+resource "pingdom_maintenance" "test" {
+	description    = "%s"
+	from           = "2066-01-05T22:10:00+08:00"
+	to             = "2066-01-05T23:59:00+08:00"
+	effectiveto    = "2088-10-22T06:07:08+08:00"
+	recurrencetype = "week"
+	repeatevery    = 4
+	uptimeids      = [pingdom_check.test.id]
+}
+`, name, name)
+}

--- a/pingdom/resource_pingdom_occurrence.go
+++ b/pingdom/resource_pingdom_occurrence.go
@@ -1,0 +1,354 @@
+package pingdom
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nordcloud/go-pingdom/pingdom"
+	"github.com/nordcloud/go-pingdom/solarwinds"
+	"log"
+	"time"
+)
+
+func resourcePingdomOccurrences() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePingdomOccurrencesCreate,
+		ReadContext:   resourcePingdomOccurrencesRead,
+		UpdateContext: resourcePingdomOccurrencesUpdate,
+		DeleteContext: resourcePingdomOccurrencesDelete,
+		Schema: map[string]*schema.Schema{
+			"maintenance_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"effective_from": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"effective_to": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"from": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"to": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: false,
+				Computed: true,
+			},
+		},
+	}
+}
+
+type OccurrenceGroup pingdom.ListOccurrenceQuery
+
+func timeParse(timeStr string) (time.Time, error) {
+	return time.Parse(time.RFC3339, timeStr)
+}
+
+func timeFormat(unixTime int64) string {
+	return time.Unix(unixTime, 0).Format(time.RFC3339)
+}
+
+func getTime(attr string, d *schema.ResourceData) (int64, bool, error) {
+	v, ok := d.GetOk(attr)
+	if ok {
+		t, err := timeParse(v.(string))
+		if err != nil {
+			return 0, false, err
+		}
+		return t.Unix(), true, nil
+	}
+	return 0, false, nil
+}
+
+func NewOccurrenceGroupWithResourceData(d *schema.ResourceData) (*OccurrenceGroup, error) {
+	q := OccurrenceGroup{}
+
+	// required
+	if v, ok := d.GetOk("maintenance_id"); ok {
+		q.MaintenanceId = int64(v.(int))
+	}
+
+	if v, ok, err := getTime("effective_from", d); err != nil {
+		return nil, err
+	} else if ok {
+		q.From = v
+	}
+
+	if v, ok, err := getTime("effective_to", d); err != nil {
+		return nil, err
+	} else if ok {
+		q.To = v
+	}
+
+	return &q, nil
+}
+
+// ID returns unique id for an OccurrenceGroup. An OccurrenceGroup is essentially a query against Maintenance Occurrence.
+// The result of query can overlap, so there is no unique resource id for queries on the Pingdom side.
+func (g *OccurrenceGroup) ID() string {
+	return solarwinds.RandString(32)
+}
+
+func (g *OccurrenceGroup) List(client *pingdom.Client) ([]pingdom.Occurrence, error) {
+	return client.Occurrences.List(pingdom.ListOccurrenceQuery(*g))
+}
+
+func (g *OccurrenceGroup) Populate(client *pingdom.Client, d *schema.ResourceData) error {
+	sample, size, err := g.Sample(client)
+	if err != nil {
+		return err
+	}
+	for k, v := range map[string]interface{}{
+		"from":           timeFormat(sample.From),
+		"to":             timeFormat(sample.To),
+		"effective_from": timeFormat(g.From),
+		"effective_to":   timeFormat(g.To),
+		"maintenance_id": g.MaintenanceId,
+		"size":           size,
+	} {
+		if err = d.Set(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *OccurrenceGroup) Sample(client *pingdom.Client) (*pingdom.Occurrence, int, error) {
+	occurrences, err := g.List(client)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(occurrences) == 0 {
+		return nil, 0, fmt.Errorf("there are no occurrences matching query: %#v", g)
+	}
+	return &occurrences[0], len(occurrences), nil
+}
+
+func (g *OccurrenceGroup) Size(client *pingdom.Client) (int, error) {
+	occurrences, err := g.List(client)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(occurrences), nil
+}
+
+func (g *OccurrenceGroup) MustExists(client *pingdom.Client) error {
+	size, err := g.Size(client)
+	if err != nil {
+		return err
+	}
+	if size == 0 {
+		return fmt.Errorf("there are no occurrences matching query: %#v", g)
+	}
+	return nil
+}
+
+func (g *OccurrenceGroup) Update(client *pingdom.Client, from int64, to int64) error {
+	occurrenceUpdate := pingdom.Occurrence{
+		From: from,
+		To:   to,
+	}
+	return g.groupOp(client, func(occurrence pingdom.Occurrence) (interface{}, error) {
+		return client.Occurrences.Update(occurrence.Id, occurrenceUpdate)
+	})
+}
+
+func (g *OccurrenceGroup) Delete(client *pingdom.Client) error {
+	return g.groupOp(client, func(occurrence pingdom.Occurrence) (interface{}, error) {
+		return client.Occurrences.Delete(occurrence.Id)
+	})
+}
+
+func (g *OccurrenceGroup) groupOp(client *pingdom.Client, op func(occurrence pingdom.Occurrence) (interface{}, error)) error {
+	occurrences, err := client.Occurrences.List(pingdom.ListOccurrenceQuery(*g))
+	if err != nil {
+		return err
+	}
+
+	cancelChan := make(chan bool)
+	errChan := make(chan error, len(occurrences))
+	for _, occurrence := range occurrences {
+		go func(occurrence pingdom.Occurrence) {
+			select {
+			case <-cancelChan:
+				return
+			default:
+				_, err := op(occurrence)
+				errChan <- err
+			}
+		}(occurrence)
+	}
+
+	expectTotal := len(occurrences)
+	count := 0
+	for err := range errChan {
+		if err != nil {
+			close(cancelChan)
+			return err
+		} else {
+			count++
+		}
+		if expectTotal == count {
+			break
+		}
+	}
+	return nil
+}
+
+func resourcePingdomOccurrencesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Pingdom
+
+	g, err := NewOccurrenceGroupWithResourceData(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var from, to int64
+	if v, ok, err := getTime("from", d); err != nil {
+		return diag.FromErr(err)
+	} else if ok {
+		from = v
+	}
+	if v, ok, err := getTime("to", d); err != nil {
+		return diag.FromErr(err)
+	} else if ok {
+		to = v
+	}
+
+	if (from == 0 && to != 0) || (from != 0 && to == 0) {
+		return diag.Errorf("'from' and 'to' must be provided at the same time, current values are from: %d, to: %d", from, to)
+	}
+
+	log.Printf("[DEBUG] Retrieve occurrences with query: %#v", g)
+	if err := g.Populate(client, d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(g.ID())
+
+	var newFrom, newTo int64
+	if v, ok, err := getTime("from", d); err != nil {
+		return diag.FromErr(err)
+	} else if ok {
+		newFrom = v
+	}
+	if v, ok, err := getTime("to", d); err != nil {
+		return diag.FromErr(err)
+	} else if ok {
+		newTo = v
+	}
+
+	if from != 0 && to != 0 && (from != newFrom || to != newTo) {
+		log.Printf("User specifies new 'from' and 'to' upon creation, from: %d, to: %d", from, to)
+		if err := g.Update(client, from, to); err != nil {
+			return diag.FromErr(err)
+		}
+		if err := g.Populate(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return nil
+}
+
+func resourcePingdomOccurrencesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Pingdom
+
+	g, err := NewOccurrenceGroupWithResourceData(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] Retrieve occurrences with query: %#v", g)
+	if err := g.Populate(client, d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourcePingdomOccurrencesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Pingdom
+
+	g, err := NewOccurrenceGroupWithResourceData(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var updated bool
+
+	if d.HasChanges("effective_from") || d.HasChanges("effective_to") {
+		log.Printf("[DEBUG] Retrieve occurrences with query: %#v", g)
+		if err := g.Populate(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+		updated = true
+	}
+
+	if d.HasChanges("from") || d.HasChanges("to") {
+		var from, to int64
+		if v, ok, err := getTime("from", d); err != nil {
+			return diag.FromErr(err)
+		} else if ok {
+			from = v
+		}
+		if v, ok, err := getTime("to", d); err != nil {
+			return diag.FromErr(err)
+		} else if ok {
+			to = v
+		}
+
+		if from == 0 || to == 0 {
+			return diag.Errorf("'from' and 'to' must be provided at the same time, current values are from: %d, to: %d", from, to)
+		}
+
+		log.Printf("[DEBUG] Occurrence update from: %d, to: %d", from, to)
+
+		if err := g.Update(client, from, to); err != nil {
+			return diag.FromErr(err)
+		}
+		updated = true
+	}
+
+	if updated {
+		if err := g.Populate(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return nil
+}
+
+func resourcePingdomOccurrencesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Pingdom
+
+	occurrence, err := NewOccurrenceGroupWithResourceData(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = occurrence.Delete(client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/pingdom/resource_pingdom_occurrence_test.go
+++ b/pingdom/resource_pingdom_occurrence_test.go
@@ -1,0 +1,166 @@
+package pingdom
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/nordcloud/go-pingdom/solarwinds"
+	"strconv"
+	"testing"
+	"text/template"
+	"time"
+)
+
+func TestAccOccurrence_basic(t *testing.T) {
+	occurrenceNum := 3
+	maintenance := getMaintenance(time.Duration(occurrenceNum))
+	resourceName := "pingdom_occurrence.test"
+
+	var from, to string
+	from = maintenance["From"]
+	if v, err := timeParse(maintenance["To"]); err != nil {
+		t.Fatal(err)
+	} else {
+		to = timeFormat(v.Add(1 * time.Hour).Unix())
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckOccurrenceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOccurrenceBasicConfig(maintenance, from, to),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "from", from),
+					resource.TestCheckResourceAttr(resourceName, "to", to),
+					resource.TestCheckResourceAttr(resourceName, "size", strconv.Itoa(occurrenceNum+1)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOccurrence_update(t *testing.T) {
+	occurrenceNum := 3
+	maintenance := getMaintenance(time.Duration(occurrenceNum))
+	resourceName := "pingdom_occurrence.test"
+
+	var from, to string
+	from = maintenance["From"]
+	if v, err := timeParse(maintenance["To"]); err != nil {
+		t.Fatal(err)
+	} else {
+		to = timeFormat(v.Add(1 * time.Hour).Unix())
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckOccurrenceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOccurrenceBasicConfig(maintenance, "", ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "from", maintenance["From"]),
+					resource.TestCheckResourceAttr(resourceName, "to", maintenance["To"]),
+					resource.TestCheckResourceAttr(resourceName, "size", strconv.Itoa(occurrenceNum+1)),
+				),
+			},
+			{
+				Config: testAccOccurrenceBasicConfig(maintenance, from, to),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "from", from),
+					resource.TestCheckResourceAttr(resourceName, "to", to),
+					resource.TestCheckResourceAttr(resourceName, "size", strconv.Itoa(occurrenceNum+1)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckOccurrenceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Clients).Pingdom
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "pingdom_occurrence" {
+			continue
+		}
+
+		g := OccurrenceGroup{}
+		v, err := strconv.ParseInt(rs.Primary.Attributes["maintenance_id"], 10, 64)
+		if err != nil {
+			return err
+		}
+		g.MaintenanceId = v
+
+		t, err := timeParse(rs.Primary.Attributes["effective_from"])
+		if err != nil {
+			return err
+		}
+		g.From = t.Unix()
+
+		t, err = timeParse(rs.Primary.Attributes["effective_to"])
+		if err != nil {
+			return err
+		}
+		g.To = t.Unix()
+
+		if size, err := g.Size(client); err != nil {
+			return err
+		} else if size != 0 {
+			return fmt.Errorf("the occurrence has not been deleted, %d left", size)
+		}
+	}
+	return nil
+}
+
+func getMaintenance(occurrenceNum time.Duration) map[string]string {
+	now := time.Now()
+	from := now.Add(1 * time.Hour)
+	to := from.Add(1 * time.Hour)
+	return map[string]string{
+		"Description": "terraform resource test - " + solarwinds.RandString(10),
+		"From":        timeFormat(from.Unix()),
+		"To":          timeFormat(to.Unix()),
+		"EffectiveTo": timeFormat(to.Add(occurrenceNum * 24 * time.Hour).Unix()),
+	}
+}
+
+func testAccOccurrenceBasicConfig(maintenance map[string]string, from string, to string) string {
+	t := template.Must(template.New("basicConfig").Parse(`
+{{with .maintenance}}
+resource "pingdom_maintenance" "test" {
+	description = "{{.Description}}"
+	from = "{{.From}}"
+	to = "{{.To}}"
+	recurrencetype = "day"
+	repeatevery = 1
+	effectiveto = "{{.EffectiveTo}}"
+}
+{{end}}
+
+resource "pingdom_occurrence" "test" {
+	maintenance_id = pingdom_maintenance.test.id
+	effective_from = pingdom_maintenance.test.from
+	effective_to = pingdom_maintenance.test.effectiveto
+	{{if .from}}
+	from = "{{.from}}"
+	{{end}}
+	{{if .to}}
+	to = "{{.to}}"
+	{{end}}
+}
+`))
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, map[string]interface{}{
+		"maintenance": maintenance,
+		"from":        from,
+		"to":          to,
+	}); err != nil {
+		panic(err)
+	}
+	result := buf.String()
+	return result
+}

--- a/pingdom/resource_pingdom_team_test.go
+++ b/pingdom/resource_pingdom_team_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/nordcloud/go-pingdom/pingdom"
 )
 
 func TestAccResourcePingdomTeam_basic(t *testing.T) {
@@ -54,7 +53,7 @@ func TestAccResourcePingdomTeam_basic(t *testing.T) {
 }
 
 func testAccCheckPingdomTeamDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*pingdom.Client)
+	client := testAccProvider.Meta().(*Clients).Pingdom
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "pingdom_team" {

--- a/pingdom/resource_pingdom_user.go
+++ b/pingdom/resource_pingdom_user.go
@@ -1,0 +1,202 @@
+package pingdom
+
+import (
+	"context"
+	"errors"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nordcloud/go-pingdom/solarwinds"
+	"log"
+	"time"
+)
+
+const (
+	DeleteUserRetryTimeout = 1 * time.Minute
+)
+
+func resourceSolarwindsUser() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSolarwindsUserCreate,
+		ReadContext:   resourceSolarwindsUserRead,
+		UpdateContext: resourceSolarwindsUserUpdate,
+		DeleteContext: resourceSolarwindsUserDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"email": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"role": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"products": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"role": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func userFromResource(d *schema.ResourceData) (*solarwinds.User, error) {
+	user := solarwinds.User{}
+
+	// required
+	if v, ok := d.GetOk("email"); ok {
+		user.Email = v.(string)
+	}
+
+	if v, ok := d.GetOk("role"); ok {
+		user.Role = v.(string)
+	}
+
+	if v, ok := d.GetOk("products"); ok {
+		interfaceSlice := v.(*schema.Set).List()
+		user.Products = expandUserProducts(interfaceSlice)
+	}
+
+	return &user, nil
+}
+
+func expandUserProducts(l []interface{}) []solarwinds.Product {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := make([]solarwinds.Product, 0, len(l))
+	for _, tfMapRaw := range l {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		product := solarwinds.Product{}
+		if name, ok := tfMap["name"].(string); ok && name != "" {
+			product.Name = name
+		}
+		if role, ok := tfMap["role"].(string); ok && role != "" {
+			product.Role = role
+		}
+		m = append(m, product)
+	}
+
+	return m
+}
+
+func resourceSolarwindsUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Solarwinds
+
+	user, err := userFromResource(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] User create configuration: %#v", d.Get("email"))
+	err = client.UserService.Create(*user)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(user.Email)
+	return resourceSolarwindsUserRead(ctx, d, meta)
+}
+
+func resourceSolarwindsUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Solarwinds
+
+	email := d.Id()
+	user, err := client.UserService.Retrieve(email)
+	if err != nil {
+		return diag.Errorf("error retrieving user with email %v", email)
+	}
+	if user == nil {
+		d.SetId("")
+		return nil
+	}
+
+	for k, v := range map[string]interface{}{
+		"email":    user.Email,
+		"role":     user.Role,
+		"products": flattenUserProducts(user.Products),
+	} {
+		if err := d.Set(k, v); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return nil
+}
+
+func flattenUserProducts(l []solarwinds.Product) []interface{} {
+	if l == nil {
+		return []interface{}{}
+	}
+	sets := make([]interface{}, 0, len(l))
+	for _, item := range l {
+		tfMap := map[string]interface{}{
+			"name": item.Name,
+			"role": item.Role,
+		}
+		sets = append(sets, tfMap)
+	}
+
+	return sets
+}
+
+func resourceSolarwindsUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Solarwinds
+	if d.HasChanges("role", "products") {
+		user, err := userFromResource(d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		log.Printf("[DEBUG] User update configuration: %#v", user)
+
+		if err = client.UserService.Update(*user); err != nil {
+			return diag.Errorf("Error updating user: %s", err)
+		}
+	}
+
+	return resourceSolarwindsUserRead(ctx, d, meta)
+}
+
+func resourceSolarwindsUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Clients).Solarwinds
+
+	id := d.Id()
+	err := resource.RetryContext(ctx, DeleteUserRetryTimeout, func() *resource.RetryError {
+		if err := client.UserService.Delete(id); err != nil {
+			var clientErr *solarwinds.ClientError
+			ok := errors.As(err, &clientErr)
+			if ok && solarwinds.ErrCodeDeleteActiveUserException == clientErr.StatusCode {
+				return resource.NonRetryableError(err)
+			}
+			return resource.RetryableError(err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return diag.Errorf("error deleting user: %s", err)
+	}
+
+	return nil
+}

--- a/pingdom/resource_pingdom_user_test.go
+++ b/pingdom/resource_pingdom_user_test.go
@@ -1,0 +1,175 @@
+package pingdom
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/nordcloud/go-pingdom/solarwinds"
+	"html/template"
+	"testing"
+)
+
+func TestAccUser_basic(t *testing.T) {
+	email := acctest.RandString(10) + "@foo.com"
+	resourceName := "pingdom_user.test"
+	user := solarwinds.User{
+		Email: email,
+		Role:  "MEMBER",
+		Products: []solarwinds.Product{
+			{
+				Name: "APPOPTICS",
+				Role: "MEMBER",
+			},
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserBasicConfig(user),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExist(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "role", "MEMBER"),
+					resource.TestCheckResourceAttr(resourceName, "products.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "products.0.name", "APPOPTICS"),
+					resource.TestCheckResourceAttr(resourceName, "products.0.role", "MEMBER"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccUser_update(t *testing.T) {
+	email := acctest.RandString(10) + "@foo.com"
+	resourceName := "pingdom_user.test"
+	user := solarwinds.User{
+		Email: email,
+		Role:  "MEMBER",
+		Products: []solarwinds.Product{
+			{
+				Name: "APPOPTICS",
+				Role: "MEMBER",
+			},
+		},
+	}
+	userUpdate := user
+	userUpdate.Role = "ADMIN"
+	userUpdate.Products = append(userUpdate.Products, solarwinds.Product{
+		Name: "PINGDOM",
+		Role: "VIEWER",
+	})
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserBasicConfig(user),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExist(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "role", user.Role),
+					resource.TestCheckResourceAttr(resourceName, "products.#", fmt.Sprint(len(user.Products))),
+					resource.TestCheckResourceAttr(resourceName, "products.0.name", user.Products[0].Name),
+					resource.TestCheckResourceAttr(resourceName, "products.0.role", user.Products[0].Role),
+				),
+			},
+			{
+				Config: testAccUserBasicConfig(userUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExist(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "role", userUpdate.Role),
+					resource.TestCheckResourceAttr(resourceName, "products.#", fmt.Sprint(len(userUpdate.Products))),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "products.*", map[string]string{
+						"name": userUpdate.Products[0].Name,
+						"role": userUpdate.Products[0].Role,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "products.*", map[string]string{
+						"name": userUpdate.Products[1].Name,
+						"role": userUpdate.Products[1].Role,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckUserDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Clients).Solarwinds
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "pingdom_user" {
+			continue
+		}
+
+		email := rs.Primary.ID
+		user, err := client.UserService.Retrieve(email)
+		if err != nil {
+			return err
+		}
+		if user != nil {
+			return fmt.Errorf("user for resource (%s) still exists", email)
+		}
+	}
+	return nil
+}
+
+func testAccCheckUserExist(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no id is set")
+		}
+
+		email := rs.Primary.ID
+		client := testAccProvider.Meta().(*Clients).Solarwinds
+		user, err := client.UserService.Retrieve(email)
+		if err != nil {
+			return err
+		}
+		if user == nil {
+			return fmt.Errorf("user for resource (%s) not found", email)
+		}
+		return nil
+	}
+}
+
+func testAccUserBasicConfig(user solarwinds.User) string {
+	t := template.Must(template.New("basicConfig").Parse(`
+resource "pingdom_user" "test" {
+	email = "{{.Email}}"
+	role = "{{.Role}}"
+	{{range .Products}}
+	products {
+		name = "{{.Name}}"
+		role = "{{.Role}}"
+	}
+	{{end}}
+}
+`))
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, user); err != nil {
+		panic(err)
+	}
+	result := buf.String()
+	return result
+}

--- a/pingdom/utils.go
+++ b/pingdom/utils.go
@@ -1,0 +1,35 @@
+package pingdom
+
+import (
+	"bytes"
+	"fmt"
+	"hash/crc32"
+)
+
+// String hashes a string to a unique hashcode.
+//
+// crc32 returns a uint32, but for our use we need
+// and non negative integer. Here we cast to an integer
+// and invert it if the result is negative.
+func String(s string) int {
+	v := int(crc32.ChecksumIEEE([]byte(s)))
+	if v >= 0 {
+		return v
+	}
+	if -v >= 0 {
+		return -v
+	}
+	// v == MinInt
+	return 0
+}
+
+// Strings hashes a list of strings to a unique hashcode.
+func Strings(strings []string) string {
+	var buf bytes.Buffer
+
+	for _, s := range strings {
+		buf.WriteString(fmt.Sprintf("%s-", s))
+	}
+
+	return fmt.Sprintf("%d", String(buf.String()))
+}


### PR DESCRIPTION
* [MCTB-547] Upgrade Pingdom provider to use v2 SDK

* Upgrade Pingdom terraform provider from SDK from v1 to v2.
* Add DNS support to the pingdom check resource.
* Add acceptance test for contact and team data source.

* add pingdom_user resource

* pingdom_user resource refactoring and acctest

* update README of pingdom_user resource

* Add test case for update pingdom_user resource

* Change the dependency till its PR is merged

* Only do initialization if acceptance test is intended

* Minor fix after merging

* update go-client dependency to latest version

* use nordcloud go-client dependency

* [MCTB-531] Add DNS check on Pingdom provider

* Add DNS check on Pingdom terraform provider.
* Write acceptance tests for exsiting resource and data source.
* Add `verify_certificate` and `ssl_down_days_before` attributes on HTTP Check.

* add support for occurrence resource

* [MCTB-461] Add maintenance resource

* tidy go mod

* add support for occurrence resource, part2

* update tests to use maintenance resource

* Change time format to RFC3339

* use string type for time attributes of occurrence

* update acceptance test of occurrence to use new time format

* use personal go-pingdom repo before PR is merged

* change go-pingdom dep to nordcloud repo

* fix some linter warnings

* remove unused dependency from go.sum

Co-authored-by: Jian Zhang <cdljianz@nordcloud.com>
Co-authored-by: chszchen <chszchen@cn.ibm.com>